### PR TITLE
De-dupe messages containing '<' and '"' in the blamer

### DIFF
--- a/lib/blamer/message.rb
+++ b/lib/blamer/message.rb
@@ -23,7 +23,9 @@ module Blamer
         b
       else
         occurrence.message = occurrence.message.gsub(/\A"/, '').gsub(/"\Z/, '').strip
-        occurrences = environment.occurrences.where("\"occurrences\".\"metadata\" LIKE ?", "%#{occurrence.message}%").joins(:bug).where(bugs: bug_search_criteria)
+        json_message = ActiveSupport::JSON.encode(occurrence.message)
+
+        occurrences = environment.occurrences.where("\"occurrences\".\"metadata\" LIKE ?", "%#{json_message}%").joins(:bug).where(bugs: bug_search_criteria)
 
         if occurrences.empty?
           environment.bugs.create! bug_attributes.merge(bug_search_criteria).merge(class_name: occurrence.bug.class_name)

--- a/lib/blamer/message.rb
+++ b/lib/blamer/message.rb
@@ -22,8 +22,7 @@ module Blamer
         b.deploy = deploy
         b
       else
-        # This call to partition is used to remove speech marks (") from around the message.
-        occurrence.message = occurrence.message.partition(/[^"]+/)[1]
+        occurrence.message = occurrence.message.gsub(/\A"/, '').gsub(/"\Z/, '').strip
         occurrences = environment.occurrences.where("\"occurrences\".\"metadata\" LIKE ?", "%#{occurrence.message}%").joins(:bug).where(bugs: bug_search_criteria)
 
         if occurrences.empty?


### PR DESCRIPTION
Metadata is serialised, which has some interesting ramifications. For our purposes, we've ended up escaping "<" to a Unicode escape, and then the LIKE finds nothing.
