### PR TITLE
Remove user information from emails

### DIFF
--- a/app/views/notification_mailer/assign.text.erb
+++ b/app/views/notification_mailer/assign.text.erb
@@ -15,8 +15,6 @@ in <%= @bug.file %>
 in <%= @bug.file %>:<%= @bug.line %>
 <% end %>
 
-<%= @bug.message_template %>
-
 ----
 
 Is it your fault?

--- a/app/views/notification_mailer/blame.text.erb
+++ b/app/views/notification_mailer/blame.text.erb
@@ -15,8 +15,6 @@ in <%= @bug.file %>
 in <%= @bug.file %>:<%= @bug.line %>
 <% end %>
 
-<%= @bug.message_template %>
-
 ----
 
 Is it your fault?
@@ -37,17 +35,6 @@ Is this not really a bug?
 
 You should take one of the above three actions -- don't just let the bug sit
 there!
-
-----
-
-<% if @bug.occurrences.first %>
-
-Stack trace of initial occurrence:
-
-<%= render_backtrace(@bug.occurrences.first.faulted_backtrace).indent(2) %>
-
-----
-<% end %>
 
         Yours truly,
         Squash

--- a/app/views/notification_mailer/comment.text.erb
+++ b/app/views/notification_mailer/comment.text.erb
@@ -7,12 +7,6 @@ in <%= @bug.file %>
 in <%= @bug.file %>:<%= @bug.line %>
 <% end %>
 
-<%= @bug.message_template %>
-
-His/her comment was:
-
-<%= email_quote @comment.body %>
-
 More details at <%= project_environment_bug_url @bug.environment.project, @bug.environment, @bug, anchor: 'comments' %>
 
         Yours truly,

--- a/app/views/notification_mailer/critical.text.erb
+++ b/app/views/notification_mailer/critical.text.erb
@@ -14,7 +14,5 @@ in <%= @bug.file %>
 in <%= @bug.file %>:<%= @bug.line %>
 <% end %>
 
-<%= @bug.message_template %>
-
         Yours truly,
         Squash

--- a/app/views/notification_mailer/deploy.text.erb
+++ b/app/views/notification_mailer/deploy.text.erb
@@ -15,7 +15,5 @@ in <%= @bug.file %>
 in <%= @bug.file %>:<%= @bug.line %>
 <% end %>
 
-<%= @bug.message_template %>
-
         Yours truly,
         Squash

--- a/app/views/notification_mailer/initial.text.erb
+++ b/app/views/notification_mailer/initial.text.erb
@@ -13,17 +13,5 @@ in <%= @bug.file %>
 in <%= @bug.file %>:<%= @bug.line %>
 <% end %>
 
-<%= @bug.message_template %>
-
-<% if @bug.occurrences.first %>
-----
-
-Stack trace of initial occurrence:
-
-<%= render_backtrace(@bug.occurrences.first.faulted_backtrace).indent(2) %>
-
-----
-<% end %>
-
         Yours truly,
         Squash

--- a/app/views/notification_mailer/occurrence.text.erb
+++ b/app/views/notification_mailer/occurrence.text.erb
@@ -12,42 +12,6 @@ in <%= @bug.file %>
 in <%= @bug.file %>:<%= @bug.line %>
 <% end %>
 
-THE OCCURRENCE
-
-<%= @occurrence.message %>
-
-<% if @occurrence.web? %>
-<% if @occurrence.url %>
-Request: <%=  @occurrence.request_method %> <%= @occurrence.url.to_s %>
-<% else %>
-Request: <%=  @occurrence.request_method %> (invalid URL)
-<% end %>
-<% end %>
-<% if @occurrence.rails? %>
-Controller: <%= @occurrence.controller %>
-Action: <%= @occurrence.action %>
-<% end %>
-<% if @occurrence.server? %>
-Hostname: <%= @occurrence.hostname %>
-PID: <%= @occurrence.pid %>
-<% end %>
-<% if @occurrence.client? %>
-Build: <%= @occurrence.build %>
-Device: <%= @occurrence.device_type %>
-OS: <%= @occurrence.operating_system %>
-<% end %>
-<% if @occurrence.mobile? %>
-Network Operator: <%= @occurrence.network_operator %>
-Network Type: <%= @occurrence.network_type %>
-<% end %>
-<% if @occurrence.browser? %>
-Web Browser: <%= @occurrence.browser_name %> (<%= @occurrence.browser_version %>)
-<% end %>
-
-Stack trace:
-
-<%= render_backtrace(@occurrence.faulted_backtrace).indent(2) %>
-
         Yours truly,
         Squash
 ---

--- a/app/views/notification_mailer/reopened.text.erb
+++ b/app/views/notification_mailer/reopened.text.erb
@@ -15,8 +15,6 @@ in <%= @bug.file %>
 in <%= @bug.file %>:<%= @bug.line %>
 <% end %>
 
-<%= @bug.message_template %>
-
 You should revisit the bug and make sure that it was actually fixed. If an
 additional fix is required, update the fix commit under the Management page.
 

--- a/app/views/notification_mailer/resolved.text.erb
+++ b/app/views/notification_mailer/resolved.text.erb
@@ -15,8 +15,6 @@ in <%= @bug.file %>
 in <%= @bug.file %>:<%= @bug.line %>
 <% end %>
 
-<%= @bug.message_template %>
-
         Yours truly,
         Squash
 ---

--- a/app/views/notification_mailer/threshold.text.erb
+++ b/app/views/notification_mailer/threshold.text.erb
@@ -15,7 +15,5 @@ in <%= @bug.file %>
 in <%= @bug.file %>:<%= @bug.line %>
 <% end %>
 
-<%= @bug.message_template %>
-
         Yours truly,
         Squash


### PR DESCRIPTION
There are privacy risks involved in exposing exception information over email.
The message attached to an exception counts here, as some errors (including
those from the database) end up including user-controlled text.
