### PR TITLE
Enable password authentication in development

### DIFF
--- a/config/environments/development/authentication.yml
+++ b/config/environments/development/authentication.yml
@@ -1,0 +1,5 @@
+---
+strategy: password
+registration_enabled: true
+password:
+  salt: HgcImNvgv64dkeodVtyrfg==


### PR DESCRIPTION
This makes it much easier to test locally as you don't need to setup
access to Google Auth.

Unlike the previous attempt at this, this only adds a new file into
development environments - it doesn't touch anything on prod or test.